### PR TITLE
Add camera to container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,6 +400,7 @@ session:
 			-e NVIDIA_DRIVER_CAPABILITIES=all \
 			-e DISPLAY=${DISPLAY} \
 			-v /dev/bus/usb:/dev/bus/usb \
+			-v /dev/camera:/dev/camera \
 			--device-cgroup-rule='c 189:* rmw' \
 			--device /dev/video0 \
 			--volume='/dev/input:/dev/input' \
@@ -417,6 +418,7 @@ session:
 			--net=host \
 			-e DISPLAY=${DISPLAY} \
 			-v /dev/bus/usb:/dev/bus/usb \
+			-v /dev/camera:/dev/camera \
 			--device-cgroup-rule='c 189:* rmw' \
 			--device /dev/video0 \
 			--volume='/dev/input:/dev/input' \


### PR DESCRIPTION
Add `/dev/camera` to container.

## Summary by Sourcery

Enhancements:
- Add /dev/camera bind mount to session docker run commands for both GPU and CPU variants to enable camera access.